### PR TITLE
Remove DataPoint fade-in/out

### DIFF
--- a/src/components/PointCloud.tsx
+++ b/src/components/PointCloud.tsx
@@ -136,10 +136,10 @@ export const PointCloud: React.FC<Props> = ({ points, lights, frames }) => {
         </>
       )}
       {pointsRef.current !== null && lights[0].current !== null && (
-        <EffectComposer autoClear={false}>
+        <EffectComposer>
           <SelectiveBloom
-            lights={lights}
-            selection={pointsRef}
+            lights={lights[0].current}
+            selection={pointsRef.current}
             kernelSize={2}
             luminanceThreshold={0}
             luminanceSmoothing={0.4}


### PR DESCRIPTION
@codeincarnate I think we should remove this feature. It's a nice visual feature to have but there are some issues that it causes and most importantly it causes a continuous refresh when streaming data. I was also thinking that maybe it would feel a bit slow for a user and we should keep with the rest of the visualisation and show data immediately.