### PR TITLE
Update to Apache 2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,109 +1,201 @@
-Please read this Grafana Enterprise Plugin License Agreement (the “Agreement”) carefully before using Grafana (as defined below), which is offered by raintank, Inc. dba Grafana Labs or its affiliated Legal Entities (“Grafana Labs”).
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-By downloading Enterprise Plugins or using them in any manner, You agree that You have read and agree to be bound by the terms of this Agreement.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-If You are accessing Grafana on behalf of a Legal Entity, You represent and warrant that You have the authority to agree to these terms on its behalf and the right to bind that Legal Entity to this Agreement.Use of Grafana is expressly conditioned upon Your assent to all the terms of this Agreement, to the exclusion of all other terms.
+   1. Definitions.
 
-1. Definitions.In addition to other terms defined elsewhere in this Agreement, the terms below have the following meanings.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-(a) “Grafana” shall mean the dashboard and analytics software provided by Grafana Labs, including both Grafana itself,  and Grafana Enterprise Plugins, as defined below.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-(b) “Grafana OSS” shall mean the open source version of Grafana, available free of charge under the AGPLv3 license at
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-https://github.com/grafana/grafana
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-(c) “Enterprise Plugins” shall mean the additional plugins made available by Grafana Labs and previously referred to as Premium Plugins, the use of which is subject to additional terms set out below.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-(d) “Contribution” shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Grafana Labs for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, “submitted” means any form of electronic, verbal, or written communication sent to Grafana Labs or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Grafana Labs for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as “Not a Contribution.”
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-(e) “Contributor” shall mean any copyright owner or individual or Legal Entity authorized by the copyright owner, other than Grafana Labs, from whom Grafana Labs receives a Contribution that Grafana Labs subsequently incorporates within the Work.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-(f) “Derivative Works” shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work, such as a translation, abridgement, condensation, or any other recasting, transformation, or adaptation for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-(g) “Legal Entity” shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, “control” means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-(h) “License” shall mean the terms and conditions for use, reproduction, and distribution of a Work as defined by this Agreement.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-(i) “Licensor” shall mean Grafana Labs or a Contributor, as applicable.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-(j) “Object” form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-(k) “Source” form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-(l) “Third Party Works” shall mean Works, including Contributions, and other technology owned by a person or Legal Entity other than Grafana Labs, as indicated by a copyright notice that is included in or attached to such Works or technology.
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-(m) “Work” shall mean the work of authorship, whether in Source or Object form, made available under a License, as indicated by a copyright notice that is included in or attached to the work.
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-(n) “You” (or “Your”) shall mean an individual or Legal Entity exercising permissions granted by this License.
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-2. Licenses.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-(a) License to Grafana OSS is governed by a separate License from this one (currently the AGPLv3 License). This License can be found in the source tree of Grafana OSS.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-Grafana OSS is a no-cost, entry-level license and as such, contains the following disclaimers: NOTWITHSTANDING ANYTHING TO THE CONTRARY HEREIN, GRAFANA OSS IS PROVIDED “AS IS” AND “AS AVAILABLE”, AND ALL EXPRESS OR IMPLIED WARRANTIES ARE EXCLUDED AND DISCLAIMED, INCLUDING WITHOUT LIMITATION THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND ANY WARRANTIES ARISING BY STATUTE OR OTHERWISE IN LAW OR FROM COURSE OF DEALING, COURSE OF PERFORMANCE, OR USE IN TRADE. For clarity, the terms of this Agreement, other than the relevant definitions in Section 1 and this Section 2(a) do not apply to Grafana OSS.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-(b) License to Enterprise Plugins.
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-i Grant of Copyright License: Subject to the terms of this Agreement, Licensor hereby grants to You a worldwide, non-exclusive, non-transferable limited license to reproduce, prepare Enterprise Derivative Works (as defined below) of, publicly display, publicly perform, sublicense, and distribute Enterprise Plugins for Your business purposes, for so long as You are not in violation of this Section 2(b) and have a valid support subscription.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-ii Grant of Patent License: Subject to the terms of this Agreement, Licensor hereby grants to You a worldwide, non-exclusive, non-transferable limited patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer Enterprise Plugins, where such license applies only to those patent claims licensable by Licensor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted.If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-iii License to Third Party Works: From time to time Grafana Labs may use, or provide You access to, Third Party Works in connection Enterprise Plugins. You acknowledge and agree that in addition to this Agreement, Your use of Third Party Works is subject to all other terms and conditions set forth in the License provided with or contained in such Third Party Works.Some Third Party Works may be licensed to You solely for use with Enterprise Plugins under the terms of a third party License, or as otherwise notified by Grafana Labs, and not under the terms of this Agreement.You agree that the owners and third party licensors of Third Party Works are intended third party beneficiaries to this Agreement.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-3. Trial License. If You have signed up for a trial or evaluation of Enterprise Plugins, Your License to Enterprise Plugins is granted without charge for the trial or evaluation period specified when You signed up, or if no term was specified, for thirty (30) calendar days, provided that Your License is granted solely for purposes of Your internal evaluation of Enterprise Plugins during the trial or evaluation period (a “Trial License”).You may not use Enterprise Plugins under a Trial License more than once in any twelve (12) month period.Grafana Labs may revoke a Trial License at any time and for any reason. Sections 7 and 9 of this Agreement do not apply to Trial Licenses.
+   END OF TERMS AND CONDITIONS
 
-4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+   APPENDIX: How to apply the Apache License to your work.
 
-(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-(b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+   Copyright {yyyy} {name of copyright owner}
 
-(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-(d) If the Work includes a “NOTICE” text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear.The contents of the NOTICE file are for informational purposes only and do not modify the License.You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+       http://www.apache.org/licenses/LICENSE-2.0
 
-You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
-
-(e) Enterprise Derivative Works: Derivative Works of Enterprise Plugins (“Enterprise Derivative Works”) may be made, reproduced and distributed in any medium, with or without modifications, in Source or Object form, provided that each Enterprise Derivative Work will be considered to include a License to Enterprise Plugins and thus will be subject to the payment of fees to Grafana Labs by any user of the Enterprise Derivative Work.
-
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in Grafana by You to Grafana Labs shall be under the terms and conditions of our CLA
-
-without any additional terms or conditions, payments of royalties or otherwise to Your benefit. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement You may have executed with Grafana Labs regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
-
-7. Limited Warranty.
-
-(a) Warranties. Grafana Labs warrants to You that: (i) Enterprise Plugins will materially perform in accordance with the applicable documentation for ninety (90) days after initial delivery to You; and (ii) any professional services performed by Grafana Labs under this Agreement will be performed in a workmanlike manner, in accordance with general industry standards.
-
-(b) Exclusions. Grafana Labs’ warranties in this Section 7 do not extend to problems that result from: (i) Your failure to implement updates issued by Grafana Labs during the warranty period; (ii) any alterations or additions (including Enterprise Derivative Works and Contributions) to Grafana not performed by or at the direction of Grafana Labs; (iii) failures that are not reproducible by Grafana Labs; (iv) operation of Enterprise Plugins in violation of this Agreement or not in accordance with its documentation; (v) failures caused by software, hardware or products not licensed or provided by Grafana Labs hereunder; or (vi) Third Party Works.
-
-(c) Remedies. In the event of a breach of a warranty under this Section 7, Grafana Labs will, at its discretion and cost, either repair, replace or re-perform the applicable Works or services or refund a portion of fees previously paid to Grafana Labs that are associated with the defective Works or services. This is Your exclusive remedy, and Grafana Labs’ sole liability, arising in connection with the limited warranties herein.
-
-8. Disclaimer of Warranty. Except as set out in Section 7, unless required by applicable law, Licensor provides the Work (and each Contributor provides its Contributions) on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, arising out of course of dealing, course of performance, or usage in trade, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, CORRECTNESS, RELIABILITY, or FITNESS FOR A PARTICULAR PURPOSE, all of which are hereby disclaimed.You are solely responsible for determining the appropriateness of using or redistributing Works and assume any risks associated with Your exercise of permissions under the applicable License for such Works.
-
-9. Limited Indemnity.
-
-(a) Indemnity. Grafana Labs will defend, indemnify and hold You harmless against any third party claims, liabilities or expenses incurred (including reasonable attorneys’ fees), as well as amounts finally awarded in a settlement or a non-appealable judgement by a court (“Losses”), to the extent arising from any claim or allegation by a third party that Enterprise Plugins infringes or misappropriates a valid United States patent, copyright or trade secret right of a third party; provided that You give Grafana Labs: (i) prompt written notice of any such claim or allegation; (ii) sole control of the defense and settlement thereof; and (iii) reasonable cooperation and assistance in such defense or settlement.If any Work within Enterprise Plugins becomes or, in Grafana Labs’ opinion, is likely to become, the subject of an injunction, Grafana Labs may, at its option, (A) procure for You the right to continue using such Work, (B) replace or modify such Work so that it becomes non-infringing without substantially compromising its functionality, or, if (A) and (B) are not commercially practicable, then (C) terminate Your license to the allegedly infringing Work and refund to You a prorated portion of the prepaid and unearned fees for such infringing Work.The foregoing states the entire liability of Grafana Labs with respect to infringement of patents, copyrights, trade secrets or other intellectual property rights.
-
-(b) Exclusions. The foregoing obligations shall not apply to: (i) Works modified by any party other than Grafana Labs (including Enterprise Derivative Works and Contributions), if the alleged infringement relates to such modification, (ii) Works combined or bundled with any products, processes or materials not provided by Grafana Labs where the alleged infringement relates to such combination, (iii) use of a version of Enterprise Plugins other than the version that was current at the time of such use, as long as a non-infringing version had been released, (iv) any Works created to Your specifications, (v) infringement or misappropriation of any proprietary right in which You have an interest, or (vi) Third Party Works.You will defend, indemnify and hold Grafana Labs harmless against any Losses arising from any such claim or allegation, subject to conditions reciprocal to those in Section 9(a).
-
-10. Limitation of Liability. In no event and under no legal or equitable theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts), and notwithstanding anything in this Agreement to the contrary, shall Licensor or any Contributor be liable to You for (i) any amounts in excess, in the aggregate, of the fees paid by You to Grafana Labs under this Agreement in the twelve (12) months preceding the date the first cause of liability arose), or (ii) any indirect, special, incidental, punitive, exemplary, reliance, or consequential damages of any character arising as a result of this Agreement or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, profits, data or data use, work stoppage, computer failure or malfunction, cost of procurement of substitute goods, technology or services, or any and all other commercial damages or losses), even if such Licensor or Contributor has been advised of the possibility of such damages. THESE LIMITATIONS SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY LIMITED REMEDY.
-
-11. Accepting Warranty or Additional Liability. While redistributing Works or Derivative Works thereof, and without limiting your obligations under Section 4, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold Grafana Labs and each other Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
-
-12. General.
-
-(a) Relationship of Parties. You and Grafana Labs are independent contractors, and nothing herein shall be deemed to constitute either party as the agent or representative of the other or both parties as joint venturers or partners for any purpose.
-
-(b) Export Control. You shall comply with the U.S. Foreign Corrupt Practices Act and all applicable export laws, restrictions and regulations of the U.S. Department of Commerce, and any other applicable U.S. and foreign authority.
-
-(c) Assignment. This Agreement and the rights and obligations herein may not be assigned or transferred, in whole or in part, by You without the prior written consent of Grafana Labs.Any assignment in violation of this provision is void.This Agreement shall be binding upon, and inure to the benefit of, the successors and permitted assigns of the parties.
-
-(d) Governing Law. This Agreement shall be governed by and construed under the laws of the State of New York and the United States without regard to conflicts of laws provisions thereof, and without regard to the Uniform Computer Information Transactions Act.
-
-(e) Attorneys’ Fees. In any action or proceeding to enforce rights under this Agreement, the prevailing party shall be entitled to recover its costs, expenses and attorneys’ fees.
-
-(f) Severability. If any provision of this Agreement is held to be invalid, illegal or unenforceable in any respect, that provision shall be limited or eliminated to the minimum extent necessary so that this Agreement otherwise remains in full force and effect and enforceable.
-
-(g) Entire Agreement; Waivers; Modification. This Agreement constitutes the entire agreement between the parties relating to the subject matter hereof and supersedes all proposals, understandings, or discussions, whether written or oral, relating to the subject matter of this Agreement and all past dealing or industry custom. The failure of either party to enforce its rights under this Agreement at any time for any period shall not be construed as a waiver of such rights. No changes, modifications or waivers to this Agreement will be effective unless in writing and signed by both parties.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
This updates the license to Apache 2.0. To my knowledge we are currently using this for plugins (at least the newer ones I've looked at).