### PR TITLE
Bump XYZChart to Beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,8 @@
 
 ## 0.1.0
 
+Release in Beta.
+
+## 0.0.1
+
 Initial release.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ https://user-images.githubusercontent.com/199847/223649247-580aec80-2182-4c32-bf
 
 The XYZ Chart includes typical 3D camera controls so that data can panned, zoomed, and rotated. This allows for straightforward analysis from various perspectives.
 
-## Alpha
+## Beta
 
-This plugin is currently in alpha. Many changes are expected so please pay attention to new versions being released.
+This plugin is currently in beta. Many changes are expected so please pay attention to new versions being released.
 
 ## Implementation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-labs-grafana-3-d-scatter-panel",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
   "type": "panel",
   "name": "XYZ Chart",
-  "state": "alpha",
+  "state": "beta",
   "id": "grafana-xyzchart-panel",
   "info": {
     "description": "XYZ chart",


### PR DESCRIPTION
Since the panel is already an external one that can be installed, we can bump it to beta so that we eliminate the extra step of adding `enable_alpha=true` in the config file.